### PR TITLE
Stop overflow in Three.js game states

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -141,6 +141,7 @@ class Client {
       this.renderer.setSize( window.innerWidth, window.innerHeight );
       this.renderer.outputEncoding = THREE.sRGBEncoding;
 
+      document.body.style.overflow = 'hidden';
       document.body.appendChild( this.renderer.domElement );
 
       this.currentState = this.GAMESTATES.PLAY;


### PR DESCRIPTION
We use overflow vertical scrolling in the waiting state and we turn it off when we are in the initial state of the Three.js game